### PR TITLE
Bump Python target to 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = { file = "LICENSE.txt" }
 maintainers = [{ name = "Bas des Tombe", email = "bas.des.tombe@pwn.nl" }]
 name = "nhflodata"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.14"
 version = "1.2.0"
 
 dependencies = ["pyyaml>=6.0.1"]
@@ -41,7 +41,7 @@ test = [
 
 [tool.hatch.envs.default]
 installer = "uv"
-python = "3.13"
+python = "3.14"
 
 [tool.hatch.envs.lintformat]
 detached = true


### PR DESCRIPTION
Move the dev/CI Python target to 3.14: hatch env `python`, `requires-python = ">=3.14"`, and ruff `target-version = "py314"` (where configured).