### PR TITLE
Derive package version from git tags via hatch-vcs

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/.github/workflows/data-validation.yml
+++ b/.github/workflows/data-validation.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # hatch-vcs needs the tag history to derive the version
+          filter: blob:none # full history is only needed for tags; skip the heavy data blobs
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/data-validation.yml
+++ b/.github/workflows/data-validation.yml
@@ -16,6 +16,8 @@ jobs:
       HATCH_VERBOSE: 1
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # hatch-vcs needs the tag history to derive the version
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ jobs:
       HATCH_VERBOSE: 1
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # hatch-vcs needs the tag history to derive the version
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # hatch-vcs needs the tag history to derive the version
+          filter: blob:none # full history is only needed for tags; skip the heavy data blobs
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "hatchling.build"
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 
 [project]
 authors = [{ name = "Bas des Tombe", email = "bas.des.tombe@pwn.nl" }]
@@ -16,13 +16,13 @@ classifiers = [
   "Topic :: Utilities",
 ]
 description = "Data part of the NHFLO modeling environment owned by HHNK, Artesia, and PWN."
+dynamic = ["version"]
 keywords = ["NHFLO"]
 license = { file = "LICENSE.txt" }
 maintainers = [{ name = "Bas des Tombe", email = "bas.des.tombe@pwn.nl" }]
 name = "nhflodata"
 readme = "README.md"
 requires-python = ">=3.14"
-version = "1.2.0"
 
 dependencies = ["pyyaml>=6.0.1"]
 
@@ -38,6 +38,9 @@ test = [
   "yamale",
   "yamllint",
 ]
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.envs.default]
 installer = "uv"

--- a/src/nhflodata/__init__.py
+++ b/src/nhflodata/__init__.py
@@ -1,4 +1,8 @@
 """Utilities for working with NHFLO data."""
 
 # ruff: noqa: F401
+from importlib.metadata import version
+
 from nhflodata.get_paths import create_new_dataset, get_abs_data_path
+
+__version__ = version("nhflodata")


### PR DESCRIPTION
## Why

The static `version = "1.2.0"` never changed while `main` moved, so pip users updating an existing environment silently kept stale code: pip treats a `nhflodata @ git+...@main` requirement as satisfied when the installed version equals the freshly resolved one — verified empirically that not even `pip install -U` picks up new commits; only `--force-reinstall` did. hatch+uv setups were unaffected, but plain pip needs the version to actually increase.

## What

- hatch-vcs (setuptools-scm) derives the version from git tags at build time: a tagged commit builds exactly as its tag, every commit after it as `1.2.1.devN+g<sha>` — unique and strictly increasing per commit, so all installers pick up changes without manual bumps.
- Anchor tag `v1.2.0` pushed on the previous main tip (matches the old static version, no downgrade anywhere).
- `fetch-depth: 0` in the two workflows that install the package — a shallow tagless checkout otherwise derives a `0.1.devN` fallback version (cosmetic; tests never asserted on it).
- `.git_archival.txt` + `.gitattributes` (`export-subst`) so GitHub 'Download ZIP' archives of commits reachable from a tag still build correctly.

## Verified

Installed from this branch with both pip 25 and uv 0.10: version resolves to `1.2.1.dev1+g096c3e784`. With increasing versions, a plain `pip install` over an existing environment now upgrades when `main` moves (tested with a real stale-commit scenario).

## Release process from now on

Cut a release by tagging: `git tag -a v1.3.0 -m ... && git push origin v1.3.0`. No version-bump commits needed; the version line in pyproject.toml is gone.